### PR TITLE
Roll forward to more recent govc by default.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 ---
 
 # defaults file for govc
-govc_version: "0.13.0"
+govc_version: "0.18.0"
 govc_path: /usr/bin
 govc_tmp: /tmp
 govc_file: "{{govc_path}}/govc"


### PR DESCRIPTION
The "find" command added in 0.14 is very useful.